### PR TITLE
Temporary workaround to handle `into_iter_err_on_gc_types`

### DIFF
--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -65,6 +65,17 @@ impl From<wasmparser::FuncType> for TypeInfo {
     }
 }
 
+// TODO(dhil): Remove this when `into_iter_err_on_gc_types` has been
+// redesigned.
+impl From<wasmparser::FuncOrContType> for TypeInfo {
+    fn from(t: wasmparser::FuncOrContType) -> Self {
+        match t {
+            wasmparser::FuncOrContType::Func(f) => f.into(),
+            wasmparser::FuncOrContType::Cont(_) => todo!("continuation types are not supported"),
+        }
+    }
+}
+
 pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
     match tpe {
         wasmparser::ValType::I32 => Ok(ValType::I32),

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -137,8 +137,13 @@ impl RemoveItem {
                         TypeSectionReader::new(section.data, 0)?.into_iter_err_on_gc_types(),
                         Item::Type,
                         |me, ty, section| {
-                            me.translate_func_type(ty,section)?;
-                            Ok(())
+                            match ty {
+                                wasmparser::FuncOrContType::Func(ty) => {
+                                    me.translate_func_type(ty,section)?;
+                                    Ok(())
+                                },
+                                wasmparser::FuncOrContType::Cont(_) => Err(Error::unsupported("Cont types are not supported yet.")),
+                            }
                         },
                     )?;
                 },

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -246,7 +246,12 @@ impl<'a> Module<'a> {
                 Payload::End(_) => {}
                 Payload::TypeSection(s) => {
                     for ty in s.into_iter_err_on_gc_types() {
-                        self.types.push(ty?);
+                        match ty? {
+                            wasmparser::FuncOrContType::Func(ty) => self.types.push(ty),
+                            wasmparser::FuncOrContType::Cont(_) => {
+                                unimplemented!("Continuation types are not supported yet.")
+                            }
+                        }
                     }
                 }
                 Payload::ImportSection(s) => {

--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -344,6 +344,10 @@ impl<'a> Metadata<'a> {
                 Payload::TypeSection(reader) => {
                     types = reader
                         .into_iter_err_on_gc_types()
+                        .map(|ty| {
+                            ty.expect("Continuation types are not supported yet.")
+                                .unwrap_func()
+                        })
                         .collect::<Result<Vec<_>, _>>()?;
                 }
 


### PR DESCRIPTION
Upstream has introduced the function `into_iter_err_on_gc_types` which iterates over core types, but errors on gc types (because they are not yet implemented). On upstream this means the function will only ever return `FuncType`s, but we need continuation types as well. So, this patch introduces a temporary sum type `FuncOrContType` such that we can return either. Eventually upstream will have to deal with gc types, and at that point we can revert from this workaround.