### PR TITLE
Explicit continuation type in the IR

### DIFF
--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{
-    BinaryReaderError, FuncType, GlobalType, HeapType, MemoryType, RefType, TableType, ValType,
+    BinaryReaderError, ContType, FuncType, GlobalType, HeapType, MemoryType, RefType, TableType, ValType,
     WasmFeatures,
 };
 use std::ops::Range;
@@ -217,7 +217,7 @@ pub trait WasmModuleResources {
     /// Returns the `FuncType` associated with the given function index.
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
     /// Return the `Cont` type associated with the given type index.
-    fn cont_type_at(&self, at: u32) -> Option<u32>;
+    fn cont_type_at(&self, at: u32) -> Option<&ContType>;
     /// Returns the element type at the given index.
     fn element_type_at(&self, at: u32) -> Option<RefType>;
     /// Checks whether the function type t1 is a subtype of the function type t2.
@@ -293,7 +293,7 @@ where
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
     }
-    fn cont_type_at(&self, at: u32) -> Option<u32> {
+    fn cont_type_at(&self, at: u32) -> Option<&ContType> {
         T::cont_type_at(self, at)
     }
     fn check_value_type(
@@ -359,7 +359,7 @@ where
         T::type_of_function(self, func_idx)
     }
 
-    fn cont_type_at(&self, at: u32) -> Option<u32> {
+    fn cont_type_at(&self, at: u32) -> Option<&ContType> {
         T::cont_type_at(self, at)
     }
 

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -14,8 +14,8 @@
  */
 
 use crate::{
-    BinaryReaderError, ContType, FuncType, GlobalType, HeapType, MemoryType, RefType, TableType, ValType,
-    WasmFeatures,
+    BinaryReaderError, ContType, FuncType, GlobalType, HeapType, MemoryType, RefType, TableType,
+    ValType, WasmFeatures,
 };
 use std::ops::Range;
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -9,8 +9,8 @@ use crate::limits::*;
 use crate::readers::Matches;
 use crate::validator::core::arc::MaybeOwned;
 use crate::{
-    BinaryReaderError, ConstExpr, ContType, Data, DataKind, Element, ElementKind, ExternalKind, FuncType,
-    Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result, StorageType,
+    BinaryReaderError, ConstExpr, ContType, Data, DataKind, Element, ElementKind, ExternalKind,
+    FuncType, Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result, StorageType,
     StructuralType, SubType, Table, TableInit, TableType, TagType, TypeRef, ValType, VisitOperator,
     WasmFeatures, WasmModuleResources,
 };
@@ -1217,10 +1217,7 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
     }
 
     fn cont_type_at(&self, at: u32) -> Option<&ContType> {
-        Some(
-            self.types[*self.module.types.get(at as usize)?]
-                .unwrap_cont(),
-        )
+        Some(self.types[*self.module.types.get(at as usize)?].unwrap_cont())
     }
 }
 
@@ -1290,10 +1287,7 @@ impl WasmModuleResources for ValidatorResources {
 
     // Gives the index of the function
     fn cont_type_at(&self, at: u32) -> Option<&ContType> {
-        Some(
-            self.0.snapshot.as_ref().unwrap()[*self.0.types.get(at as usize)?]
-                .unwrap_cont(),
-        )
+        Some(self.0.snapshot.as_ref().unwrap()[*self.0.types.get(at as usize)?].unwrap_cont())
     }
 }
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -9,7 +9,7 @@ use crate::limits::*;
 use crate::readers::Matches;
 use crate::validator::core::arc::MaybeOwned;
 use crate::{
-    BinaryReaderError, ConstExpr, Data, DataKind, Element, ElementKind, ExternalKind, FuncType,
+    BinaryReaderError, ConstExpr, ContType, Data, DataKind, Element, ElementKind, ExternalKind, FuncType,
     Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result, StorageType,
     StructuralType, SubType, Table, TableInit, TableType, TagType, TypeRef, ValType, VisitOperator,
     WasmFeatures, WasmModuleResources,
@@ -557,7 +557,7 @@ impl Module {
             bail!(offset, "gc proposal must be enabled to use subtypes");
         }
 
-        self.check_structural_type(&ty.structural_type, features, offset)?;
+        self.check_structural_type(&ty.structural_type, types, features, offset)?;
 
         if let Some(supertype_index) = ty.supertype_idx {
             // Check the supertype exists, is not final, and the subtype matches it.
@@ -595,6 +595,7 @@ impl Module {
     fn check_structural_type(
         &mut self,
         ty: &StructuralType,
+        types: &TypeList,
         features: &WasmFeatures,
         offset: usize,
     ) -> Result<()> {
@@ -610,12 +611,14 @@ impl Module {
                     ));
                 }
             }
-            StructuralType::Cont(type_index) => {
-                if (*type_index as usize) >= self.types.len() {
+            StructuralType::Cont(ct) => {
+                let type_index = ct.0;
+                if (type_index as usize) >= self.types.len() {
                     return Err(BinaryReaderError::new("invalid type index", offset));
                     // TODO(dhil): tidy up error message.
-                    // technically need to check that it points to a function type, and not just another continuation ref.
                 }
+                // Check that the type index points to a valid function type.
+                let _ft = self.func_type_at(type_index, types, offset)?;
             }
             StructuralType::Array(t) => {
                 if !features.gc {
@@ -1213,11 +1216,10 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         self.module.function_references.contains(&idx)
     }
 
-    fn cont_type_at(&self, at: u32) -> Option<u32> {
+    fn cont_type_at(&self, at: u32) -> Option<&ContType> {
         Some(
             self.types[*self.module.types.get(at as usize)?]
-                .as_cont_func_index()
-                .unwrap(),
+                .unwrap_cont(),
         )
     }
 }
@@ -1287,11 +1289,10 @@ impl WasmModuleResources for ValidatorResources {
     }
 
     // Gives the index of the function
-    fn cont_type_at(&self, at: u32) -> Option<u32> {
+    fn cont_type_at(&self, at: u32) -> Option<&ContType> {
         Some(
             self.0.snapshot.as_ref().unwrap()[*self.0.types.get(at as usize)?]
-                .as_cont_func_index()
-                .unwrap(),
+                .unwrap_cont(),
         )
     }
 }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -23,8 +23,8 @@
 // the various methods here.
 
 use crate::{
-    limits::MAX_WASM_FUNCTION_LOCALS, BinaryReaderError, BlockType, BrTable, ContType, HeapType, Ieee32,
-    Ieee64, MemArg, RefType, Result, ResumeTable, ValType, VisitOperator, WasmFeatures,
+    limits::MAX_WASM_FUNCTION_LOCALS, BinaryReaderError, BlockType, BrTable, ContType, HeapType,
+    Ieee32, Ieee64, MemArg, RefType, Result, ResumeTable, ValType, VisitOperator, WasmFeatures,
     WasmFuncType, WasmModuleResources, V128,
 };
 use std::ops::{Deref, DerefMut};
@@ -1053,7 +1053,8 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
             // Next check that ts1' <: ts1''.
             for (tagty, lblty) in labeltys.zip(tagtype.inputs()) {
                 if !self.resources.matches(tagty, lblty) {
-                    bail!(self.offset, "type mismatch between tag type and label type") // TODO(dhil): tidy up
+                    bail!(self.offset, "type mismatch between tag type and label type")
+                    // TODO(dhil): tidy up
                 }
             }
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -6,9 +6,9 @@ use super::{
 };
 use crate::validator::names::KebabString;
 use crate::{
-    ArrayType, BinaryReaderError, ContType, Export, ExternalKind, FuncType, GlobalType, Import, MemoryType,
-    PrimitiveValType, RefType, Result, StructType, StructuralType, SubType, TableType, TypeRef,
-    ValType,
+    ArrayType, BinaryReaderError, ContType, Export, ExternalKind, FuncType, GlobalType, Import,
+    MemoryType, PrimitiveValType, RefType, Result, StructType, StructuralType, SubType, TableType,
+    TypeRef, ValType,
 };
 use indexmap::{IndexMap, IndexSet};
 use std::collections::HashMap;

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::validator::names::KebabString;
 use crate::{
-    ArrayType, BinaryReaderError, Export, ExternalKind, FuncType, GlobalType, Import, MemoryType,
+    ArrayType, BinaryReaderError, ContType, Export, ExternalKind, FuncType, GlobalType, Import, MemoryType,
     PrimitiveValType, RefType, Result, StructType, StructuralType, SubType, TableType, TypeRef,
     ValType,
 };
@@ -286,12 +286,23 @@ impl Type {
         }
     }
 
+    /// Converts the type to a core continuation type.
+    pub fn unwrap_cont(&self) -> &ContType {
+        match self {
+            Type::Sub(SubType {
+                structural_type: StructuralType::Cont(ct),
+                ..
+            }) => ct,
+            _ => panic!("not a continuation type"),
+        }
+    }
+
     /// If the given type is a continuation type, give the index of its
     /// corresponding function type
     pub fn as_cont_func_index(&self) -> Option<u32> {
         match self {
             Self::Sub(SubType {
-                structural_type: StructuralType::Cont(fi),
+                structural_type: StructuralType::Cont(ContType(fi)),
                 ..
             }) => Some(*fi),
             _ => None,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -720,9 +720,9 @@ impl Printer {
                 self.end_group(); // `struct`
                 r
             }
-            StructuralType::Cont(type_index) => {
+            StructuralType::Cont(ct) => {
                 self.start_group("cont");
-                let r = self.print_cont_type(state, *type_index)?;
+                let r = self.print_cont_type(state, ct)?;
                 self.end_group();
                 r
             }
@@ -808,9 +808,9 @@ impl Printer {
         Ok(ty.params().len() as u32)
     }
 
-    fn print_cont_type(&mut self, state: &State, type_index: u32) -> Result<u32> {
+    fn print_cont_type(&mut self, state: &State, ct: &ContType) -> Result<u32> {
         self.result.push(' ');
-        self.print_idx(&state.core.type_names, type_index)?;
+        self.print_idx(&state.core.type_names, ct.0)?;
         Ok(0)
     }
 


### PR DESCRIPTION
This patch adds an explicit continuation type in the IR, following the style of `Func`, `Array`, and `Struct` more closely.

The new type is named `ContType` and it simply wraps a `u32`, which is intended to point to a function type in the module local type store.