### PR TITLE
Fix `matches` relation for `ContType`.

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -950,9 +950,23 @@ impl Matches for ContType {
     where
         F: Fn(u32) -> &'a SubType,
     {
-        let x = type_at(self.0);
-        let y = type_at(other.0);
-        x.matches(y, type_at)
+        if self.0 == other.0 {
+            return true;
+        }
+        let x = type_at(self.0); // returns a SubType
+        let y = type_at(other.0); // returns a SubType
+                                  // TODO(dhil): we subvert the whole check for
+                                  // `matches(SubType, SubType)` here by projecting the
+                                  // structural types. If we do not project them, then the
+                                  // `matches` on `SubType` may fail for valid continuation
+                                  // types due to the implementation (in particular the test of
+                                  // `!other.is_final` which may evaluate to `false` causing the
+                                  // subtyping check to inadvertently short-circuit). Looking at
+                                  // the other uses of elements returned from `type_at` this
+                                  // appears to be correct. However, we should revisit this once
+                                  // we have integrate the GC proposal into the reference
+                                  // interpreter.
+        x.structural_type.matches(&y.structural_type, type_at)
     }
 }
 


### PR DESCRIPTION
This patch fixes a bug in the implementation of the `matches` relation for `ContType`. The implementation uses `type_at` to retrieve the function types pointed to by the continuation types. These function types are wrapped in a `SubType`, meaning    

```rust
let a = type_at(self.0);
let b = type_at(other.0);
a.matches(b, type_at)
```
    
will execute the `matches` implementation for `SubType` whosen implementation is
    
```rust
fn matches<'a, F>(&self, other: &Self, type_at: &F) -> bool
where
   F: Fn(u32) -> &'a SubType,
{
   !other.is_final
       && self
          .structural_type
          .matches(&other.structural_type, type_at)
}
```
    
The test `!other.is_final` is troublesome as it may inadvertently short-circuit the subtyping check of an otherwise compatible pair of types.
    
We subvert this check by projecting the structural types out, i.e.

```rust
let a = type_at(self.0);
let b = type_at(other.0);
a.structural_type.matches(&b.structural_type, type_at)
```