### PR TITLE
Slightly tweak error reporting

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -3449,9 +3449,9 @@ where
     // Typed continuations operators.
     fn visit_cont_new(&mut self, type_index: u32) -> Self::Output {
         let fidx = self.cont_type_at(type_index)?.0;
-        let rt = RefType::indexed_func(false, fidx).unwrap(); // TODO(dhil): proper error handling
+        let rt = RefType::indexed_func(false, fidx).expect("type index is too large");
         self.pop_operand(Some(ValType::Ref(rt)))?;
-        let result = RefType::indexed_func(false, type_index).unwrap(); // TODO(dhil): proper error handling
+        let result = RefType::indexed_func(false, type_index).expect("type index is too large");
         self.push_operand(ValType::Ref(result))?;
         Ok(())
     }
@@ -3485,7 +3485,7 @@ where
             None => {} // bot case
             Some(rt) => {
                 let expected = ValType::Ref(
-                    RefType::indexed_func(false, src_index).unwrap(), /* TODO(dhil): proper error handling */
+                    RefType::indexed_func(false, src_index).expect("type index is too large"),
                 );
                 if !self.resources.matches(expected, ValType::Ref(rt)) {
                     bail!(
@@ -3504,7 +3504,7 @@ where
         }
 
         // Construct the result type.
-        let result_type = RefType::indexed_func(false, dst_index).unwrap(); // TODO(dhil): proper error handling
+        let result_type = RefType::indexed_func(false, dst_index).expect("type index is too large");
 
         // Push the continuation reference.
         self.push_operand(result_type)?;
@@ -3523,7 +3523,8 @@ where
     }
     fn visit_resume(&mut self, type_index: u32, resumetable: ResumeTable) -> Self::Output {
         let ctft = self.func_repr_cont_type_at(type_index)?;
-        let expected = ValType::Ref(RefType::indexed_func(true, type_index).unwrap()); // TODO(dhil): proper error handling
+        let expected =
+            ValType::Ref(RefType::indexed_func(true, type_index).expect("type index is too large"));
         match self.pop_ref()? {
             None => {}
             Some(rt) if self.resources.matches(ValType::Ref(rt), expected) => {
@@ -3558,7 +3559,8 @@ where
         resumetable: ResumeTable,
     ) -> Self::Output {
         let ctft = self.func_repr_cont_type_at(type_index)?;
-        let expected = ValType::Ref(RefType::indexed_func(true, type_index).unwrap()); // TODO(dhil): proper error handling
+        let expected =
+            ValType::Ref(RefType::indexed_func(true, type_index).expect("type index is too large"));
         match self.pop_ref()? {
             None => {}
             Some(rt) if self.resources.matches(ValType::Ref(rt), expected) => {


### PR DESCRIPTION
This patch tweaks ever-so-slightly the error reporting for construction failure of the synthetic function reference types used in the validation of continuation instructions.