### PR TITLE
Fix validation of continuation instructions

### DIFF
--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -227,8 +227,11 @@ pub trait WasmModuleResources {
     /// The function type must be canonicalized.
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType>;
 
-    /// Return the `Cont` type associated with the given type index.
-    fn cont_type_at(&self, at: u32) -> Option<ContType>;
+    /// Return the `ContType` associated with the given id.
+    fn cont_type_at(&self, id: CoreTypeId) -> Option<ContType>;
+
+    /// Return the `FuncType` associated with the given id.
+    fn func_type_at_id(&self, id: CoreTypeId) -> Option<&Self::FuncType>;
 
     /// Returns the element type at the given index.
     ///
@@ -315,8 +318,11 @@ where
     fn type_of_function(&self, func_idx: u32) -> Option<&Self::FuncType> {
         T::type_of_function(self, func_idx)
     }
-    fn cont_type_at(&self, at: u32) -> Option<ContType> {
-        T::cont_type_at(self, at)
+    fn cont_type_at(&self, id: CoreTypeId) -> Option<ContType> {
+        T::cont_type_at(self, id)
+    }
+    fn func_type_at_id(&self, id: CoreTypeId) -> Option<&Self::FuncType> {
+        T::func_type_at_id(self, id)
     }
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
         T::check_heap_type(self, t, offset)
@@ -376,8 +382,12 @@ where
         T::type_of_function(self, func_idx)
     }
 
-    fn cont_type_at(&self, at: u32) -> Option<ContType> {
-        T::cont_type_at(self, at)
+    fn cont_type_at(&self, id: CoreTypeId) -> Option<ContType> {
+        T::cont_type_at(self, id)
+    }
+
+    fn func_type_at_id(&self, id: CoreTypeId) -> Option<&Self::FuncType> {
+        T::func_type_at_id(self, id)
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -1249,13 +1249,19 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         self.module.function_references.contains(&idx)
     }
 
-    fn cont_type_at(&self, at: u32) -> Option<ContType> {
-        let id = *self.module.types.get(at as usize)?;
+    fn cont_type_at(&self, id: CoreTypeId) -> Option<ContType> {
         let ct = match &self.types[id].composite_type {
             CompositeType::Cont(c) => c.clone(),
             _ => return None,
         };
         Some(ct)
+    }
+
+    fn func_type_at_id(&self, id: CoreTypeId) -> Option<&Self::FuncType> {
+        match &self.types[id].composite_type {
+            CompositeType::Func(f) => Some(f),
+            _ => None,
+        }
     }
 }
 
@@ -1347,15 +1353,22 @@ impl WasmModuleResources for ValidatorResources {
         self.0.function_references.contains(&idx)
     }
 
-    // Gives the index of the function
-    fn cont_type_at(&self, at: u32) -> Option<ContType> {
-        let id = *self.0.types.get(at as usize)?;
+    // Returns the continuation type at the type index, if any
+    fn cont_type_at(&self, id: CoreTypeId) -> Option<ContType> {
         let types = self.0.snapshot.as_ref().unwrap();
         let ct = match &types[id].composite_type {
             CompositeType::Cont(c) => c.clone(),
             _ => return None,
         };
         Some(ct)
+    }
+
+    fn func_type_at_id(&self, id: CoreTypeId) -> Option<&Self::FuncType> {
+        let types = self.0.snapshot.as_ref().unwrap();
+        match &types[id].composite_type {
+            CompositeType::Func(f) => Some(f),
+            _ => None,
+        }
     }
 }
 

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -298,7 +298,10 @@ mod tests {
         fn is_function_referenced(&self, _idx: u32) -> bool {
             todo!()
         }
-        fn cont_type_at(&self, _at: u32) -> Option<crate::ContType> {
+        fn cont_type_at(&self, _at: CoreTypeId) -> Option<crate::ContType> {
+            todo!()
+        }
+        fn func_type_at_id(&self, _id: CoreTypeId) -> Option<&Self::FuncType> {
             todo!()
         }
     }

--- a/tests/local/typed-continuations/cont_canonicalisation.wast
+++ b/tests/local/typed-continuations/cont_canonicalisation.wast
@@ -1,0 +1,19 @@
+(module
+
+  (type $int_to_int (func (param i32) (result i32)))
+  (type $ft (func (param i32) (result i32)))
+  (type $res_int_to_int (cont $int_to_int))
+  (type $f3_t (func (param i32) (result i32)))
+  (type $f3_ct (cont $f3_t))
+
+  (tag $e3_int_to_int (param i32) (result i32))
+
+  (func $test_case_4 (export "test_case_4") (result i32)
+
+    (block $on_e3 (result i32 (ref $res_int_to_int))
+      (resume $f3_ct (tag $e3_int_to_int $on_e3) (i32.const 49) (ref.null $f3_ct))
+      (unreachable))
+    ;; after on_e3, expected stack: [50 resumption]
+    (unreachable)
+    )
+)

--- a/tests/local/typed-continuations/cont_new.wast
+++ b/tests/local/typed-continuations/cont_new.wast
@@ -1,0 +1,16 @@
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  (func $noop)
+  (elem declare func $noop)
+
+  (func $make-cont (result (ref $ct))
+     (cont.new $ct (ref.func $noop)))
+
+  (func $f (export "f") (result i32)
+     (call $make-cont)
+     (ref.is_null))
+)
+
+(assert_return (invoke "f") (i32.const 0))

--- a/tests/local/typed-continuations/cont_resume.wast
+++ b/tests/local/typed-continuations/cont_resume.wast
@@ -1,0 +1,17 @@
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  (global $i (mut i32) (i32.const 0))
+
+  (func $g
+    (global.set $i (i32.const 42)))
+  (elem declare func $g)
+
+  (func $f (export "f") (result i32)
+    (global.set $i (i32.const 99))
+    (resume $ct (cont.new $ct (ref.func $g)))
+    (global.get $i))
+)
+
+;; (assert_return (invoke "f") (i32.const 42))

--- a/tests/local/typed-continuations/cont_suspend.wast
+++ b/tests/local/typed-continuations/cont_suspend.wast
@@ -1,0 +1,25 @@
+;; Small continuation resume test
+;; expected output:
+;; 1 : i32
+;; 2 : i32
+;; 3 : i32
+(module
+  (func $print (import "spectest" "print_i32") (param i32) (result))
+  (type $ft (func))
+  (type $ct (cont $ft))
+  (tag $h)
+  (func $f (export "f")
+    (suspend $h)
+    (call $print (i32.const 2)))
+  (func (export "run") (result i32)
+    (call $print (i32.const 1))
+    (block $on_h (result (ref $ct))
+      (resume $ct (tag $h $on_h)
+                  (cont.new $ct (ref.func $f)))
+      (unreachable))
+    (drop)
+    (call $print (i32.const 3))
+    (return (i32.const 42)))
+)
+
+(assert_return (invoke "run") (i32.const 42))

--- a/tests/snapshots/local/typed-continuations/cont_canonicalisation.wast/0.print
+++ b/tests/snapshots/local/typed-continuations/cont_canonicalisation.wast/0.print
@@ -1,0 +1,20 @@
+(module
+  (type $int_to_int (;0;) (func (param i32) (result i32)))
+  (type $ft (;1;) (func (param i32) (result i32)))
+  (type $res_int_to_int (;2;) (cont $int_to_int))
+  (type $f3_t (;3;) (func (param i32) (result i32)))
+  (type $f3_ct (;4;) (cont $f3_t))
+  (type (;5;) (func (result i32)))
+  (type (;6;) (func (result i32 (ref 2))))
+  (func $test_case_4 (;0;) (type 5) (result i32)
+    block $on_e3 (type 6) (result i32 (ref 2)) ;; label = @1
+      i32.const 49
+      ref.null 4
+      resume $f3_ct (tag 0 0 (;@1;))
+      unreachable
+    end
+    unreachable
+  )
+  (tag (;0;) (type $int_to_int) (param i32) (result i32))
+  (export "test_case_4" (func $test_case_4))
+)

--- a/tests/snapshots/local/typed-continuations/cont_new.wast/0.print
+++ b/tests/snapshots/local/typed-continuations/cont_new.wast/0.print
@@ -1,0 +1,17 @@
+(module
+  (type $ft (;0;) (func))
+  (type $ct (;1;) (cont $ft))
+  (type (;2;) (func (result (ref 1))))
+  (type (;3;) (func (result i32)))
+  (func $noop (;0;) (type $ft))
+  (func $make-cont (;1;) (type 2) (result (ref 1))
+    ref.func $noop
+    cont.new $ct
+  )
+  (func $f (;2;) (type 3) (result i32)
+    call $make-cont
+    ref.is_null
+  )
+  (export "f" (func $f))
+  (elem (;0;) declare func $noop)
+)

--- a/tests/snapshots/local/typed-continuations/cont_resume.wast/0.print
+++ b/tests/snapshots/local/typed-continuations/cont_resume.wast/0.print
@@ -1,0 +1,20 @@
+(module
+  (type $ft (;0;) (func))
+  (type $ct (;1;) (cont $ft))
+  (type (;2;) (func (result i32)))
+  (func $g (;0;) (type $ft)
+    i32.const 42
+    global.set $i
+  )
+  (func $f (;1;) (type 2) (result i32)
+    i32.const 99
+    global.set $i
+    ref.func $g
+    cont.new $ct
+    resume $ct
+    global.get $i
+  )
+  (global $i (;0;) (mut i32) i32.const 0)
+  (export "f" (func $f))
+  (elem (;0;) declare func $g)
+)

--- a/tests/snapshots/local/typed-continuations/cont_suspend.wast/0.print
+++ b/tests/snapshots/local/typed-continuations/cont_suspend.wast/0.print
@@ -1,0 +1,30 @@
+(module
+  (type $ft (;0;) (func))
+  (type $ct (;1;) (cont $ft))
+  (type (;2;) (func (param i32)))
+  (type (;3;) (func (result i32)))
+  (import "spectest" "print_i32" (func $print (;0;) (type 2)))
+  (func $f (;1;) (type $ft)
+    suspend 0
+    i32.const 2
+    call $print
+  )
+  (func (;2;) (type 3) (result i32)
+    i32.const 1
+    call $print
+    block $on_h (result (ref 1)) ;; label = @1
+      ref.func $f
+      cont.new $ct
+      resume $ct (tag 0 0 (;@1;))
+      unreachable
+    end
+    drop
+    i32.const 3
+    call $print
+    i32.const 42
+    return
+  )
+  (tag (;0;) (type $ft))
+  (export "f" (func $f))
+  (export "run" (func 2))
+)

--- a/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast/0.print
@@ -1,9 +1,0 @@
-(module
-  (type (;0;) (func))
-  (func (;0;) (type 0)
-    throw 0
-  )
-  (tag (;0;) (type 0))
-  (export "e0" (tag 0))
-  (export "throw" (func 0))
-)


### PR DESCRIPTION
Validation was broken in the presence of type canonicalisation. It is
important to *only* use canonicalised types. It is currently a little
awkward to work with raw type indices on the continuation
instructions, as they to be canonicalised before use. This patch
implements some helper functions to convert from `HeapType::concrete`
to canonicalised indices.