### PR TITLE
Pick up upstream's `into_iter_err_on_gc_types`

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -5,11 +5,8 @@ use anyhow::{anyhow, bail, Result};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::EdgeDirection;
 use smallvec::SmallVec;
+use std::collections::{hash_map::Entry, HashMap};
 use std::mem;
-use std::{
-    borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
-};
 use wasm_encoder::*;
 use wasmparser::{
     names::KebabString,

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -2,7 +2,7 @@
 
 use super::Mutator;
 use crate::module::map_type;
-use crate::{Error, Result};
+use crate::Result;
 use rand::Rng;
 use std::iter;
 
@@ -56,26 +56,20 @@ impl Mutator for AddTypeMutator {
             // Copy the existing types section over into the encoder.
             let reader = wasmparser::TypeSectionReader::new(old_types.data, 0)?;
             for ty in reader.into_iter_err_on_gc_types() {
-                match ty? {
-                    wasmparser::FuncOrContType::Func(ty) => {
-                        let params = ty
-                            .params()
-                            .iter()
-                            .copied()
-                            .map(map_type)
-                            .collect::<Result<Vec<_>, _>>()?;
-                        let results = ty
-                            .results()
-                            .iter()
-                            .copied()
-                            .map(map_type)
-                            .collect::<Result<Vec<_>, _>>()?;
-                        types.function(params, results);
-                    }
-                    wasmparser::FuncOrContType::Cont(_) => {
-                        return Err(Error::unsupported("Cont types are not supported yet."));
-                    }
-                }
+                let ty = ty?;
+                let params = ty
+                    .params()
+                    .iter()
+                    .copied()
+                    .map(map_type)
+                    .collect::<Result<Vec<_>, _>>()?;
+                let results = ty
+                    .results()
+                    .iter()
+                    .copied()
+                    .map(map_type)
+                    .collect::<Result<Vec<_>, _>>()?;
+                types.function(params, results);
             }
             // And then add our new type.
             types.function(params, results);

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -137,13 +137,8 @@ impl RemoveItem {
                         TypeSectionReader::new(section.data, 0)?.into_iter_err_on_gc_types(),
                         Item::Type,
                         |me, ty, section| {
-                            match ty {
-                                wasmparser::FuncOrContType::Func(ty) => {
-                                    me.translate_func_type(ty,section)?;
-                                    Ok(())
-                                },
-                                wasmparser::FuncOrContType::Cont(_) => Err(Error::unsupported("Cont types are not supported yet.")),
-                            }
+                            me.translate_func_type(ty,section)?;
+                            Ok(())
                         },
                     )?;
                 },

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -609,34 +609,28 @@ impl Module {
             let serialized_sig_idx = match available_types.get_mut(parsed_sig_idx as usize) {
                 None => panic!("signature index refers to a type out of bounds"),
                 Some((_, Some(idx))) => *idx as usize,
-                Some((func_type, index_store)) => match func_type {
-                    wasmparser::FuncOrContType::Func(func_type) => {
-                        let multi_value_required = func_type.results().len() > 1;
-                        let new_index = first_type_index + new_types.len();
-                        if new_index >= max_types || (multi_value_required && !multi_value_enabled)
-                        {
-                            return None;
-                        }
-                        let func_type = Rc::new(FuncType {
-                            params: func_type
-                                .params()
-                                .iter()
-                                .map(|t| convert_type(*t))
-                                .collect(),
-                            results: func_type
-                                .results()
-                                .iter()
-                                .map(|t| convert_type(*t))
-                                .collect(),
-                        });
-                        index_store.replace(new_index as u32);
-                        new_types.push(Type::Func(Rc::clone(&func_type)));
-                        new_index
+                Some((func_type, index_store)) => {
+                    let multi_value_required = func_type.results().len() > 1;
+                    let new_index = first_type_index + new_types.len();
+                    if new_index >= max_types || (multi_value_required && !multi_value_enabled) {
+                        return None;
                     }
-                    wasmparser::FuncOrContType::Cont(_) => {
-                        unimplemented!("Continuation types are not supported yet.")
-                    }
-                },
+                    let func_type = Rc::new(FuncType {
+                        params: func_type
+                            .params()
+                            .iter()
+                            .map(|t| convert_type(*t))
+                            .collect(),
+                        results: func_type
+                            .results()
+                            .iter()
+                            .map(|t| convert_type(*t))
+                            .collect(),
+                    });
+                    index_store.replace(new_index as u32);
+                    new_types.push(Type::Func(Rc::clone(&func_type)));
+                    new_index
+                }
             };
             match &new_types[serialized_sig_idx - first_type_index] {
                 Type::Func(f) => Some((serialized_sig_idx as u32, Rc::clone(f))),

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -246,12 +246,7 @@ impl<'a> Module<'a> {
                 Payload::End(_) => {}
                 Payload::TypeSection(s) => {
                     for ty in s.into_iter_err_on_gc_types() {
-                        match ty? {
-                            wasmparser::FuncOrContType::Func(ty) => self.types.push(ty),
-                            wasmparser::FuncOrContType::Cont(_) => {
-                                unimplemented!("Continuation types are not supported yet.")
-                            }
-                        }
+                        self.types.push(ty?);
                     }
                 }
                 Payload::ImportSection(s) => {

--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -348,10 +348,6 @@ impl<'a> Metadata<'a> {
                 Payload::TypeSection(reader) => {
                     types = reader
                         .into_iter_err_on_gc_types()
-                        .map(|ty| {
-                            ty.expect("Continuation types are not supported yet.")
-                                .unwrap_func()
-                        })
                         .collect::<Result<Vec<_>, _>>()?;
                 }
 


### PR DESCRIPTION
This patch reintroduces the `into_iter_err_on_gc_types` from upstream, and renames our custom implementation (as it is still needed in our fork of wasmtime).