### PR TITLE
Track whether a function body contains resume instructions.

### DIFF
--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -243,6 +243,12 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn into_allocations(self) -> FuncValidatorAllocations {
         FuncValidatorAllocations(self.validator.into_allocations())
     }
+
+    /// Returns whether the function body contains resume instructions
+    /// (resume and resume_throw).
+    pub fn resumes_continuation(&self) -> bool {
+        self.validator.resumes_continuation()
+    }
 }
 
 #[cfg(test)]

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -53,6 +53,10 @@ pub(crate) struct OperatorValidator {
     /// Offset of the `end` instruction which emptied the `control` stack, which
     /// must be the end of the function.
     end_which_emptied_control: Option<usize>,
+
+    // This flag is used to track whether the function contains any
+    // resume instructions.
+    resumes_continuation: bool,
 }
 
 // No science was performed in the creation of this number, feel free to change
@@ -226,6 +230,7 @@ impl OperatorValidator {
             operands,
             control,
             end_which_emptied_control: None,
+            resumes_continuation: false,
         }
     }
 
@@ -392,6 +397,10 @@ impl OperatorValidator {
             locals_first: clear(self.locals.first),
             locals_all: clear(self.locals.all),
         }
+    }
+
+    pub fn resumes_continuation(&self) -> bool {
+        self.resumes_continuation
     }
 }
 
@@ -3798,6 +3807,7 @@ where
         Ok(())
     }
     fn visit_resume(&mut self, type_index: u32, resumetable: ResumeTable) -> Self::Output {
+        self.resumes_continuation = true;
         let unpacked_index = UnpackedIndex::Module(type_index);
         let mut hty = HeapType::Concrete(unpacked_index);
         self.resources.check_heap_type(&mut hty, self.offset)?;
@@ -3841,6 +3851,7 @@ where
         tag_index: u32,
         resumetable: ResumeTable,
     ) -> Self::Output {
+        self.resumes_continuation = true;
         let unpacked_index = UnpackedIndex::Module(type_index);
         let mut hty = HeapType::Concrete(unpacked_index);
         self.resources.check_heap_type(&mut hty, self.offset)?;


### PR DESCRIPTION
This PR extends the public API of `FuncValidator` with predicate `resumes_continuation` which returns whether the function body contains resume instructions. This predicate can help us decide whether the vmruntime limits pointer needs to be declare in the function prelude during codegen in cranelift/wasmtime.