### PR TITLE
Fix subtyping bug in `cont.new`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,13 +84,6 @@ jobs:
         submodules: true
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-    - run: |
-        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz
-        tar xf wasi-sdk-21.0-linux.tar.gz
-        export WASI_SDK_PATH=$(pwd)/wasi-sdk-21.0
-        rustup target add wasm32-wasi
-        cd crates/wit-component/dl && bash check.sh
-      if: matrix.os == 'ubuntu-latest' && matrix.build == 'stable'
     - run: cargo test --locked --all
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
@@ -99,6 +92,22 @@ jobs:
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
+
+  testdl:
+    name: Test libdl.so
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust (rustup)
+      run: rustup update 1.77.0 --no-self-update && rustup default 1.77.0
+    - run: |
+        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz
+        tar xf wasi-sdk-21.0-linux.tar.gz
+        export WASI_SDK_PATH=$(pwd)/wasi-sdk-21.0
+        rustup target add wasm32-wasi
+        cd crates/wit-component/dl && bash check.sh
 
   wasm:
     name: Test on WebAssembly
@@ -213,6 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - testdl
       - wasm
       - rustfmt
       - fuzz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -341,7 +341,7 @@ define_wasm_features! {
         /// The WebAssembly memory64 proposal.
         pub memory64: MEMORY64(1 << 14) = false;
         /// The WebAssembly extended_const proposal.
-        pub extended_const: EXTENDED_CONST(1 << 15) = false;
+        pub extended_const: EXTENDED_CONST(1 << 15) = true;
         /// The WebAssembly component model proposal.
         pub component_model: COMPONENT_MODEL(1 << 16) = true;
         /// The WebAssembly typed function references proposal.

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -3765,7 +3765,7 @@ where
         self.resources.check_heap_type(&mut c_hty, self.offset)?;
         let f_idx = self.cont_type_of_heap_type(c_hty)?.0;
         let f_hty = f_idx.pack().expect("hty should be previously validated");
-        let expected_rt = RefType::concrete(false, f_hty);
+        let expected_rt = RefType::concrete(true, f_hty);
         self.pop_operand(Some(ValType::Ref(expected_rt)))?;
         let result =
             ValType::Ref(RefType::new(false, c_hty).expect("hty should be previously validated"));

--- a/crates/wast/src/core/func.rs
+++ b/crates/wast/src/core/func.rs
@@ -81,7 +81,7 @@ impl<'a> Parse<'a> for Func<'a> {
 ///
 /// Each local has an optional identifier for name resolution, an optional name
 /// for the custom `name` section, and a value type.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Local<'a> {
     /// An identifier that this local is resolved with (optionally) for name
     /// resolution.

--- a/crates/wit-component/README.md
+++ b/crates/wit-component/README.md
@@ -21,7 +21,7 @@ $ wasm-tools component wit component.wasm
 * Creates WebAssembly [component binaries][model] from input core WebAssembly
   modules. Input modules communicate with the [canonical ABI] to imported and
   exported interfaces described with [`*.wit` files][wit]. The wit interface is
-  either embedded directly in the core wasm binary.
+  required to be embedded directly in the core wasm binary.
 
 * Supports "adapters" which can be used to bridge legacy core WebAssembly
   imported functions into [component model][model] functions. Adapters are

--- a/crates/wit-component/dl/build.sh
+++ b/crates/wit-component/dl/build.sh
@@ -5,6 +5,8 @@
 #
 # Example: WASI_SDK_PATH=/opt/wasi-sdk bash build.sh ../libdl.so
 
+set -ex
+
 CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C relocation-model=pic" cargo build --release --target=wasm32-wasi
 $WASI_SDK_PATH/bin/clang -shared -o $1 -Wl,--whole-archive ../../../target/wasm32-wasi/release/libdl.a -Wl,--no-whole-archive
 cargo run --manifest-path ../../../Cargo.toml -- strip $1 -o $1

--- a/crates/wit-component/dl/check.sh
+++ b/crates/wit-component/dl/check.sh
@@ -1,3 +1,5 @@
+set -ex
+
 bash ./build.sh ../../../target/wasm32-wasi/release/tmp.so
 if diff ../../../target/wasm32-wasi/release/tmp.so ../libdl.so; then
   exit 0

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -654,6 +654,7 @@ fn error_matches(error: &str, message: &str) -> bool {
         || message == "malformed annotation id"
         || message == "alignment must be a power of two"
         || message == "i32 constant out of range"
+        || message == "constant expression required"
     {
         return error.contains("expected ")
             || error.contains("constant out of range")


### PR DESCRIPTION
The argument to `cont.new` is allowed to be `null`. The returned reference type is `non-null` though.