### PR TITLE
Disable playground workflow

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Build playground deployment
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'bytecodealliance'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +46,7 @@ jobs:
 
   deploy:
     name: Deploy playground
-    if: github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'bytecodealliance' && github.ref == 'refs/heads/main'
     needs: build
     permissions:
       pages: write


### PR DESCRIPTION
This PR disables the playground workflow, as it fails because we haven't configured the repository accordingly.