### PR TITLE
Automated release workflow for artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish artifacts of build
     runs-on: ubuntu-latest
     if: |
-      github.repository_owner == 'bytecodealliance'
+      github.repository_owner == 'wasmfx'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
     steps:
@@ -85,4 +85,5 @@ jobs:
         ./publish publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      if: steps.tag.outputs.push_tag == 'yes'
+      if: false && steps.tag.outputs.push_tag == 'yes'
+      # NOTE(dhil): We do not publish on crates.io


### PR DESCRIPTION
This patch attempts to enable the automated release workflow. We intend to publish only the build artifacts on GitHub.