### PR TITLE
Opcodes for continuation heap types (3)

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1685,10 +1685,10 @@ impl<'a> FromReader<'a> for RefType {
             0x6B => Ok(RefType::STRUCT.nullable()),
             0x6A => Ok(RefType::ARRAY.nullable()),
             0x6C => Ok(RefType::I31.nullable()),
-            0x68 => Ok(RefType::NOCONT.nullable()),
+            0x68 => Ok(RefType::CONT.nullable()),
             0x69 => Ok(RefType::EXN.nullable()),
             0x74 => Ok(RefType::NOEXN.nullable()),
-            0x75 => Ok(RefType::CONT.nullable()),
+            0x75 => Ok(RefType::NOCONT.nullable()),
             _ => bail!(pos, "invalid abstract heap type"),
         };
 
@@ -1764,10 +1764,10 @@ impl<'a> FromReader<'a> for AbstractHeapType {
             0x6B => Ok(Struct),
             0x6A => Ok(Array),
             0x6C => Ok(I31),
-            0x68 => Ok(NoCont),
+            0x68 => Ok(Cont),
             0x69 => Ok(Exn),
             0x74 => Ok(NoExn),
-            0x75 => Ok(Cont),
+            0x75 => Ok(NoCont),
             _ => {
                 bail!(reader.original_position(), "invalid abstract heap type");
             }


### PR DESCRIPTION
I inadvertently swapped `CONT` and `NOCONT`.